### PR TITLE
Replace native-tls dependency with rustls

### DIFF
--- a/msnp11-sdk/Cargo.toml
+++ b/msnp11-sdk/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 tokio = { version = "1", features = ["rt-multi-thread", "io-util", "net", "macros", "sync", "time"] }
 base64 = "0.22.1"
 log = { version = "0.4.27", features = ["std"] }
-reqwest = "0.12.15"
+reqwest = { version = "0.12.15", features = ["charset", "http2", "rustls-tls"], default-features = false }
 quick-xml = { version = "0.38.0", features = ["serialize"] }
 serde = { version = "1.0.219", features = ["derive"] }
 urlencoding = "2.1.3"


### PR DESCRIPTION
Replaces reqwest's default-tls feature (which currently uses native-tls -> openssl) with rustls, which removes the dependency on libssl.so.3 on linux

I'm willing to make this a cargo feature on this crate as well if need be